### PR TITLE
Add more openshift-workload-fingerprinting stakeholders.

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -52,6 +52,7 @@ orgs:
       - ri-dubey
       - dgpatelgit
       - nicolekay2
+      - sochotnicky
     members_can_create_repositories: false
     name: ""
     repos:
@@ -232,6 +233,7 @@ orgs:
           - ri-dubey
           - dgpatelgit
           - nicolekay2
+          - sochotnicky
         privacy: closed
         repos:
           ceph_drive_failure: read

--- a/github-config.yaml
+++ b/github-config.yaml
@@ -47,6 +47,11 @@ orgs:
       - mklika
       - falox
       - smarterclayton
+      - nstielau
+      - joshuawilson
+      - ri-dubey
+      - dgpatelgit
+      - nicolekay2
     members_can_create_repositories: false
     name: ""
     repos:
@@ -222,6 +227,11 @@ orgs:
           - mklika
           - falox
           - smarterclayton
+          - nstielau
+          - joshuawilson
+          - ri-dubey
+          - dgpatelgit
+          - nicolekay2
         privacy: closed
         repos:
           ceph_drive_failure: read


### PR DESCRIPTION
More stakeholders have requested access to the OpenShift Workload Fingerprinting project, so this PR updates the github-config to add them to the `Red Hat` team under the `aicoe-aiops` org