### PR TITLE
adding schwesig to members

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -315,6 +315,7 @@ orgs:
           - antter
           - amsaparov
           - margarethaley
+          - schwesig
         privacy: closed
         repos:
           ai-enablement-initiative: triage


### PR DESCRIPTION
adding Thorsten Schwesig (schwesig, tschwesi)
to
orgs:  aicoe-aiops:aicoe-aiops: members (alphabetical order)
orgs:  team-aiops: members (there wasn't an alphabetical order so far, I added at the end)